### PR TITLE
Add Claude Code column to AI tool adoption table

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ AI系開発ツールを導入している企業まとめ
 | 大日本印刷株式会社 (DNP)                   |            |           |                    | ✅           |             | （ChatGPT Enterpriseを研究開発等の部門で導入）          |
 | Zenken株式会社                        |            |           |                    | ✅           |             | （国内初、全社員にChatGPT Enterprise導入）            |
 | 株式会社リバネス                          |            |           |                    | ✅           |             | （ChatGPT Enterpriseを全社員に導入）               |
-| 株式会社リバネスナレッジ                   | ✅         | ✅        |                  | ✅           | ✅           | （APIは各種活用中。manus,Windsurf,Claude Code活用開始）[エンジニアチームをAIエージェント対応組織に変革してうまくいき始めている気がする](https://note.com/geeorgey/n/n71a0bd984115) |
-| 株式会社カカクコム                         | ✅          |           |                    |             |             | （AIコードエディタ「Cursor」を全エンジニア約500人に導入）        |
+| 株式会社リバネスナレッジ                   | ✅         | ✅        |                  | ✅           | ✅            | （APIは各種活用中。manus,Windsurf,Claude Code活用開始）[エンジニアチームをAIエージェント対応組織に変革してうまくいき始めている気がする](https://note.com/geeorgey/n/n71a0bd984115) |
+| 株式会社カカクコム                         | ✅          |           |                    |             |              | （AIコードエディタ「Cursor」を全エンジニア約500人に導入）        |
 | 株式会社エブリー                          | ✅          |           |                    |             |             | （「Cursor」を全エンジニア・PdMに導入）                  |
 | クラウドエース株式会社                       |            | ✅         |                    |             |             | （自律型AIエンジニア「Devin」を本格導入）                  |
 | 株式会社Hacobu                        | ✅          | ✅         | ✅                  | ✅           |             | （全エンジニアに「Devin」「Cursor」「ChatGPT」「GitHub Copilot」を導入）<br> [「Devin」「Cursor」「ChatGPT」をテクノロジー部門全体へ展開](https://hacobu.jp/news/15146/) <br> [「ChatGPT」と「GitHub Copilot for Business」を導入](https://hacobu.jp/news/3339/)      |

--- a/README.md
+++ b/README.md
@@ -14,50 +14,50 @@ AI系開発ツールを導入している企業まとめ
 
 
 
-| **会社名**                           | **Cursor** | **Devin** | **GitHub Copilot** | **ChatGPT** | **公式情報（例：プレスリリース等）**                      |
-| --------------------------------- | ---------- | --------- | ------------------ | ----------- | ----------------------------------------- |
-| 株式会社メルカリ                          | ✅          | ✅         | ✅                  | ✅           | （Cursor全社導入、Copilot導入で生産性向上など）            |
-| パナソニックホールディングス株式会社 (Panasonic HD) |            |           | ✅                  | ✅           | （「PX-GPT」を全社員約9万人に提供） <br>  [開発スタイルの変革！ パナソニックグループでのGitHubとGitHub Copilot導入でやってみたこと](https://assets.ctfassets.net/wfutmusr1t3h/CREJxXjTaY2iEjREUnEfK/7758a1df872ed5a0d814e09563af38b6/1730_GitHubRecapTokyo_Panasonic_20241128__.pdf)                   |
-| 日立製作所 (Hitachi)                   |            |           |                    | ✅           | （「ジェネレーティブAIセンター」創設を発表）                   |
-| NECグループ (日本電気株式会社)                |            |           |                    | ✅           | （全社でChatGPT積極活用の方針を発表）                    |
-| 三菱UFJフィナンシャル・グループ                 |            |           |                    | ✅           | （2023年夏にChatGPTを社内導入予定と発表）                |
-| SBIホールディングス株式会社 (SBIグループ)         |            |           |                    | ✅           | （2025年3月よりChatGPT Enterprise導入開始）         |
-| 大和証券株式会社                          |            |           |                    | ✅           | （全社員約9,000人にChatGPTを導入）                   |
-| 株式会社リクルート                         |            |           | ✅                  | ✅           | （Copilot全社展開予定、ChatGPT Enterprise利用）      |
-| LINEヤフー株式会社                       |            |           | ✅                  |             | （全エンジニア7,000名にGitHub Copilot導入）           |
-| ソフトバンク株式会社                        |            |           |                    | ✅           | （社内で生成AI活用を推進）                            |
-| GMOインターネットグループ株式会社                |            |           | ✅                  | ✅           | （社内でGitHub Copilot・ChatGPTを活用）            |
-| GMOペパボ株式会社                |✅            |✅           | ✅                  | ✅           | （社内でCursor, Devin, GitHub Copilot, ChatGPTを活用）            |
-| 株式会社MIXI                          |🌀           |🌀           | ✅                  | ✅           | （ChatGPT Enterpriseを全従業員に導入）             |
-| 大日本印刷株式会社 (DNP)                   |            |           |                    | ✅           | （ChatGPT Enterpriseを研究開発等の部門で導入）          |
-| Zenken株式会社                        |            |           |                    | ✅           | （国内初、全社員にChatGPT Enterprise導入）            |
-| 株式会社リバネス                          |            |           |                    | ✅           | （ChatGPT Enterpriseを全社員に導入）               |
-| 株式会社リバネスナレッジ                   | ✅         | ✅        |                  | ✅           | （APIは各種活用中。manus,Windsurf,Claude Code活用開始）[エンジニアチームをAIエージェント対応組織に変革してうまくいき始めている気がする](https://note.com/geeorgey/n/n71a0bd984115) |
-| 株式会社カカクコム                         | ✅          |           |                    |             | （AIコードエディタ「Cursor」を全エンジニア約500人に導入）        |
-| 株式会社エブリー                          | ✅          |           |                    |             | （「Cursor」を全エンジニア・PdMに導入）                  |
-| クラウドエース株式会社                       |            | ✅         |                    |             | （自律型AIエンジニア「Devin」を本格導入）                  |
-| 株式会社Hacobu                        | ✅          | ✅         | ✅                  | ✅           | （全エンジニアに「Devin」「Cursor」「ChatGPT」「GitHub Copilot」を導入）<br> [「Devin」「Cursor」「ChatGPT」をテクノロジー部門全体へ展開](https://hacobu.jp/news/15146/) <br> [「ChatGPT」と「GitHub Copilot for Business」を導入](https://hacobu.jp/news/3339/)      |
-| 株式会社ヘッドウォータース                     |            |           | ✅                  |             | （全社で「GitHub Copilot」を導入）                  |
-| 株式会社メタップス                         |            |           | ✅                  |             | （全エンジニアに「GitHub Copilot for Business」を導入） |
-| 株式会社ツクルバ                          |            |           | ✅                  |             | （全エンジニアに「GitHub Copilot」利用環境を提供）          |
-| 株式会社ワンキャリア                        |            |           | ✅                  |             | （AIコーディング支援ツール「GitHub Copilot」を導入）        |
-| ENECHANGE株式会社                     |            |           | ✅                  | ✅           | （全エンジニアにCopilot導入＆全従業員にChatGPT Plus導入）    |
-| 株式会社クリエ                           |            |           | ✅                  |             | （「GitHub Copilot Business」を2024年6月より導入）   |
-| 株式会社スカイディスク                       |            |           | ✅                  |             | （GPT-4搭載「GitHub Copilot X」を全エンジニアに導入）     |
-| 株式会社Sapeet                        |            | ✅         |                    |             | （全エンジニアが完全自律型AIエンジニア「Devin」利用可能に）         |
-| 株式会社エクスプラザ                        | ✅          |           |                    | ✅           | （全社員にCursor導入・全員がChatGPT活用）               |
-| 株式会社みずかげ製作所                       |            | ✅         |                    |             | （「Devin」導入し副業エンジニア含め活用）                   |
-| 株式会社マネーフォワード                      |            |           | ✅                  |             | （GitHub Copilot導入効果を検証・活用）                |
-| 株式会社ZOZO                          |            |           | ✅                  |             | （GitHub Copilot導入時の工夫点を紹介）                |
-| 株式会社NTTデータ                        |            |           | ✅                  |             | （2023年度に社内でGitHub Copilot先行導入・効果検証）       |
-| 株式会社ビザスク                         |            | ✅         | ✅                  | ✅          | （Cline(Vertex AI)やGenemi、AIモデルとしてはClaudeも活用している旨公開情報有り） <br> [安全で迅速なAI導入](https://tech.visasq.com/ai-development-infra-fast-start)、[ChatGPTをZapierで使う](https://tech.visasq.com/chatgpt-with-zapier) |
-| 株式会社ベースマキナ                          | ✅          | ✅         | ✅                  | ✅           | （Cursor・Copilotを開発にて全社導入、Devin・ChatGPTを必要に応じて活用）  <br> [開発期間2週間！新機能の叩き台をAIエージェント駆動で爆速開発した話](https://tech.basemachina.jp/entry/prototyping-with-ai-agent)           |
-| コクヨ株式会社                          |            | ✅         | ✅                  | ✅           | （Devin導入、Copilot導入、GPTを含めた複数LLMモデルのチャットツール有り） <br> [Devin導入記事](https://note.com/kokuyo_engineer/n/n2f4035ec6447)、[GitHub Copilot関連記事](https://note.com/kokuyo_engineer/n/n2c0572956865)、[GPTを含めた複数LLMモデルのチャットツール](https://classmethod.jp/cases/kokuyo/)            |
-| 株式会社スタディスト                          | ✅          | ✅         | ✅                  | ✅           | （全社の希望者に各アカウントを配布、Claude Teamを利用）  <br> [スタディストにおけるAIツールの柔軟な活用と効率化への道のり](https://studist.tech/studist-ai-tools-b42a78f8db7c)           |
-| 株式会社ココナラ                         | ✅          |           | ✅                  |             | （Cursor BusinessとGitHub Copilotを全社導入） <br> [いかにしてココナラはCursor Businessを導入したのか?](https://zenn.dev/coconala/articles/coconala-cursor-business-introduction) |
-| REALITY株式会社                          |            |          | ✅                  |           | （全エンジニアに「GitHub Copilot」利用環境を提供） <br> [REALITY株式会社の導入事例](https://note.com/reality_eng/n/nee88b2d864fd)           |
-| 株式会社ログラス                          |  ✅           | 🌀         | ✅               | 🌀          | （全エンジニアにCursor導入・一部にDevin導入） <br> [ログラスは全エンジニアにCursorを配ります](https://comemo.nikkei.com/n/n26dc284dcd5a) <br> [数年来の技術的負債を改修した話 - 2種類のORM並列状態からの脱却 -](https://zenn.dev/loglass/articles/94753ea267bb74) <br> [社内業務の生産性を爆上げしたGPTs / 利用推進のための取り組み](https://note.com/majackyy/n/n10b8191ef9ac?magazine_key=m56fa214ad4c6)         |
-| 株式会社CINC                          |             |         |                | ✅         | （ChatGPT Teamを全社導入） <br> [「ChatGPT Team」の全社導入後アンケートの結果に関するお知らせ](https://www.cinc-j.co.jp/news/7116/)         |
-| 株式会社リアルグローブ                     | ✅          |           | ✅                  | ✅           | （全社の希望者に各アカウントを配布、Gemini Proを全社導入） <br> [社員の働き方改革：生成AIで開発効率化とエンジニアの負担を軽減！](https://note.com/realglobe101/n/n014bcc85ccec) |
+| **会社名**                           | **Cursor** | **Devin** | **GitHub Copilot** | **ChatGPT** | **Claude Code** | **公式情報（例：プレスリリース等）**                      |
+| --------------------------------- | ---------- | --------- | ------------------ | ----------- | ------------ | ----------------------------------------- |
+| 株式会社メルカリ                          | ✅          | ✅         | ✅                  | ✅           |             | （Cursor全社導入、Copilot導入で生産性向上など）            |
+| パナソニックホールディングス株式会社 (Panasonic HD) |            |           | ✅                  | ✅           |             | （「PX-GPT」を全社員約9万人に提供） <br>  [開発スタイルの変革！ パナソニックグループでのGitHubとGitHub Copilot導入でやってみたこと](https://assets.ctfassets.net/wfutmusr1t3h/CREJxXjTaY2iEjREUnEfK/7758a1df872ed5a0d814e09563af38b6/1730_GitHubRecapTokyo_Panasonic_20241128__.pdf)                   |
+| 日立製作所 (Hitachi)                   |            |           |                    | ✅           |             | （「ジェネレーティブAIセンター」創設を発表）                   |
+| NECグループ (日本電気株式会社)                |            |           |                    | ✅           |             | （全社でChatGPT積極活用の方針を発表）                    |
+| 三菱UFJフィナンシャル・グループ                 |            |           |                    | ✅           |             | （2023年夏にChatGPTを社内導入予定と発表）                |
+| SBIホールディングス株式会社 (SBIグループ)         |            |           |                    | ✅           |             | （2025年3月よりChatGPT Enterprise導入開始）         |
+| 大和証券株式会社                          |            |           |                    | ✅           |             | （全社員約9,000人にChatGPTを導入）                   |
+| 株式会社リクルート                         |            |           | ✅                  | ✅           |             | （Copilot全社展開予定、ChatGPT Enterprise利用）      |
+| LINEヤフー株式会社                       |            |           | ✅                  |             |             | （全エンジニア7,000名にGitHub Copilot導入）           |
+| ソフトバンク株式会社                        |            |           |                    | ✅           |             | （社内で生成AI活用を推進）                            |
+| GMOインターネットグループ株式会社                |            |           | ✅                  | ✅           |             | （社内でGitHub Copilot・ChatGPTを活用）            |
+| GMOペパボ株式会社                |✅            |✅           | ✅                  | ✅           |             | （社内でCursor, Devin, GitHub Copilot, ChatGPTを活用）            |
+| 株式会社MIXI                          |🌀           |🌀           | ✅                  | ✅           |             | （ChatGPT Enterpriseを全従業員に導入）             |
+| 大日本印刷株式会社 (DNP)                   |            |           |                    | ✅           |             | （ChatGPT Enterpriseを研究開発等の部門で導入）          |
+| Zenken株式会社                        |            |           |                    | ✅           |             | （国内初、全社員にChatGPT Enterprise導入）            |
+| 株式会社リバネス                          |            |           |                    | ✅           |             | （ChatGPT Enterpriseを全社員に導入）               |
+| 株式会社リバネスナレッジ                   | ✅         | ✅        |                  | ✅           | ✅           | （APIは各種活用中。manus,Windsurf,Claude Code活用開始）[エンジニアチームをAIエージェント対応組織に変革してうまくいき始めている気がする](https://note.com/geeorgey/n/n71a0bd984115) |
+| 株式会社カカクコム                         | ✅          |           |                    |             |             | （AIコードエディタ「Cursor」を全エンジニア約500人に導入）        |
+| 株式会社エブリー                          | ✅          |           |                    |             |             | （「Cursor」を全エンジニア・PdMに導入）                  |
+| クラウドエース株式会社                       |            | ✅         |                    |             |             | （自律型AIエンジニア「Devin」を本格導入）                  |
+| 株式会社Hacobu                        | ✅          | ✅         | ✅                  | ✅           |             | （全エンジニアに「Devin」「Cursor」「ChatGPT」「GitHub Copilot」を導入）<br> [「Devin」「Cursor」「ChatGPT」をテクノロジー部門全体へ展開](https://hacobu.jp/news/15146/) <br> [「ChatGPT」と「GitHub Copilot for Business」を導入](https://hacobu.jp/news/3339/)      |
+| 株式会社ヘッドウォータース                     |            |           | ✅                  |             |             | （全社で「GitHub Copilot」を導入）                  |
+| 株式会社メタップス                         |            |           | ✅                  |             |             | （全エンジニアに「GitHub Copilot for Business」を導入） |
+| 株式会社ツクルバ                          |            |           | ✅                  |             |             | （全エンジニアに「GitHub Copilot」利用環境を提供）          |
+| 株式会社ワンキャリア                        |            |           | ✅                  |             |             | （AIコーディング支援ツール「GitHub Copilot」を導入）        |
+| ENECHANGE株式会社                     |            |           | ✅                  | ✅           |             | （全エンジニアにCopilot導入＆全従業員にChatGPT Plus導入）    |
+| 株式会社クリエ                           |            |           | ✅                  |             |             | （「GitHub Copilot Business」を2024年6月より導入）   |
+| 株式会社スカイディスク                       |            |           | ✅                  |             |             | （GPT-4搭載「GitHub Copilot X」を全エンジニアに導入）     |
+| 株式会社Sapeet                        |            | ✅         |                    |             |             | （全エンジニアが完全自律型AIエンジニア「Devin」利用可能に）         |
+| 株式会社エクスプラザ                        | ✅          |           |                    | ✅           |             | （全社員にCursor導入・全員がChatGPT活用）               |
+| 株式会社みずかげ製作所                       |            | ✅         |                    |             |             | （「Devin」導入し副業エンジニア含め活用）                   |
+| 株式会社マネーフォワード                      |            |           | ✅                  |             |             | （GitHub Copilot導入効果を検証・活用）                |
+| 株式会社ZOZO                          |            |           | ✅                  |             |             | （GitHub Copilot導入時の工夫点を紹介）                |
+| 株式会社NTTデータ                        |            |           | ✅                  |             |             | （2023年度に社内でGitHub Copilot先行導入・効果検証）       |
+| 株式会社ビザスク                         |            | ✅         | ✅                  | ✅          |             | （Cline(Vertex AI)やGenemi、AIモデルとしてはClaudeも活用している旨公開情報有り） <br> [安全で迅速なAI導入](https://tech.visasq.com/ai-development-infra-fast-start)、[ChatGPTをZapierで使う](https://tech.visasq.com/chatgpt-with-zapier) |
+| 株式会社ベースマキナ                          | ✅          | ✅         | ✅                  | ✅           |             | （Cursor・Copilotを開発にて全社導入、Devin・ChatGPTを必要に応じて活用）  <br> [開発期間2週間！新機能の叩き台をAIエージェント駆動で爆速開発した話](https://tech.basemachina.jp/entry/prototyping-with-ai-agent)           |
+| コクヨ株式会社                          |            | ✅         | ✅                  | ✅           |             | （Devin導入、Copilot導入、GPTを含めた複数LLMモデルのチャットツール有り） <br> [Devin導入記事](https://note.com/kokuyo_engineer/n/n2f4035ec6447)、[GitHub Copilot関連記事](https://note.com/kokuyo_engineer/n/n2c0572956865)、[GPTを含めた複数LLMモデルのチャットツール](https://classmethod.jp/cases/kokuyo/)            |
+| 株式会社スタディスト                          | ✅          | ✅         | ✅                  | ✅           |             | （全社の希望者に各アカウントを配布、Claude Teamを利用）  <br> [スタディストにおけるAIツールの柔軟な活用と効率化への道のり](https://studist.tech/studist-ai-tools-b42a78f8db7c)           |
+| 株式会社ココナラ                         | ✅          |           | ✅                  |             |             | （Cursor BusinessとGitHub Copilotを全社導入） <br> [いかにしてココナラはCursor Businessを導入したのか?](https://zenn.dev/coconala/articles/coconala-cursor-business-introduction) |
+| REALITY株式会社                          |            |          | ✅                  |           |             | （全エンジニアに「GitHub Copilot」利用環境を提供） <br> [REALITY株式会社の導入事例](https://note.com/reality_eng/n/nee88b2d864fd)           |
+| 株式会社ログラス                          |  ✅           | 🌀         | ✅               | 🌀          |             | （全エンジニアにCursor導入・一部にDevin導入） <br> [ログラスは全エンジニアにCursorを配ります](https://comemo.nikkei.com/n/n26dc284dcd5a) <br> [数年来の技術的負債を改修した話 - 2種類のORM並列状態からの脱却 -](https://zenn.dev/loglass/articles/94753ea267bb74) <br> [社内業務の生産性を爆上げしたGPTs / 利用推進のための取り組み](https://note.com/majackyy/n/n10b8191ef9ac?magazine_key=m56fa214ad4c6)         |
+| 株式会社CINC                          |             |         |                | ✅         |             | （ChatGPT Teamを全社導入） <br> [「ChatGPT Team」の全社導入後アンケートの結果に関するお知らせ](https://www.cinc-j.co.jp/news/7116/)         |
+| 株式会社リアルグローブ                     | ✅          |           | ✅                  | ✅           |             | （全社の希望者に各アカウントを配布、Gemini Proを全社導入） <br> [社員の働き方改革：生成AIで開発効率化とエンジニアの負担を軽減！](https://note.com/realglobe101/n/n014bcc85ccec) |
 
 **注:** 上記のチェックマーク（✅）は、各社が公式に発表・確認した導入事例に基づき記載しています。などの出典は各社のプレスリリースや公式ニュースから引用しています。


### PR DESCRIPTION
## 概要
AI開発ツール導入企業一覧テーブルに「Claude Code」列を追加しました。

## 変更内容
- **新列の追加**: 「ChatGPT」列と「公式情報」列の間に「Claude Code」列を挿入
- **テーブルヘッダーの更新**: 新しい列に対応するヘッダーを追加
- **区切り行の更新**: 新しい列に対応する区切り文字を追加
- **全企業データの更新**: 全ての企業行に新しい列を追加し、適切なステータスを設定

## 設定したステータス
- **✅ (全社導入)**: 株式会社リバネスナレッジ
  - 根拠: 公式情報に「Claude Code活用開始」の記載あり
- **空白 (導入してない)**: その他の企業
  - 公式な導入情報が確認できないため

## 確認事項
- [x] テーブルの列数が全行で一致していることを確認
- [x] 既存のフォーマットを維持
- [x] 公式情報に基づく正確なステータス設定
- [x] マークダウン構文の正確性

この変更により、Claude Codeの企業導入状況を他のAIツールと並べて比較できるようになります。