### PR TITLE
グッドパッチの公式情報追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ PRを送っていただけると大変助かります！🙌
 | 株式会社ビットキー | 🌀 | 🌀 | ✅ | 🌀 |  | Geminiを全社導入済み |
 | 株式会社ベンジャミン | ✅ | 🌀 | ✅ | 🌀 | 🌀 | AWS環境ではAmazon Q Developer CLIを利用可能、Cursor, Devin, Gemini, GitHub Copilot Enterprise, Claude Codeは申請に基づき利用可能 |
 | ツクリンク株式会社 | ✅ | ✅ | ✅ | | ✅ | Claude Code, Cursor, GitHub Copilotを希望者に配布、Gemini Proを全社導入 <br> [ツクリンクにおける生成AIツールの活用事例](https://zenn.dev/tsukulink/articles/2025-07-gen-ai-tools) |
-| [株式会社グッドパッチ](https://goodpatch.com/) | 🌀 | | ✅ | 🌀 | 🌀 | AIツールの活用ルールを社内で整備済み。GitHub Copilotは2023年3月から全エンジニア導入しており、Gemini Proは全社員に導入。その他、Chat GPT 等代表的な AI ツール含めて基本的には申請すれば導入可能で費用は会社側が負担。<br>[Goodpatch Blog-生成AI](https://goodpatch.com/blog/tag/%e7%94%9f%e6%88%90ai) <br> [Goodpatch Tech Blog-生成AI](https://goodpatch-tech.hatenablog.com/archive/category/Generative%20AI)|
+| [株式会社グッドパッチ](https://goodpatch.com/) | 🌀 | | ✅ | 🌀 | 🌀 | AIツールの活用ルールを社内で整備済み。GitHub Copilotは2023年3月から全エンジニア導入しており、Gemini Proは全社員に導入。その他、Chat GPT 等代表的な AI ツール含めて基本的には申請すれば導入可能で費用は会社側が負担。<br> [Careers-Member support](https://goodpatch.com/careers) <br>[Goodpatch Blog-生成AI](https://goodpatch.com/blog/tag/%e7%94%9f%e6%88%90ai) <br> [Goodpatch Tech Blog-生成AI](https://goodpatch-tech.hatenablog.com/archive/category/Generative%20AI)|
 | 合同会社DMM.com | | ✅ | ✅ | 🌀 |🌀 | [DevinとClineをDMMで導入しました〜トライアルから見えた成果の共有〜](https://developersblog.dmm.com/entry/2025/04/04/110000) |
 | [クレジットエンジン株式会社](https://creditengine.jp/) |  |  | ✅ |  | ✅ |全社員の希望者にGitHub Copilot,Claude Codeを支給 <br>またGoogle WorkspaceでGeminiも利用可 |
 


### PR DESCRIPTION
<img width="617" height="229" alt="image" src="https://github.com/user-attachments/assets/438d654b-5b4b-4469-bc01-b5b8dfa501fd" />

弊社の公式情報として採用情報ページに生成AIツール利用が追加されたため追記しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- ドキュメント
  - README の企業テーブルにて「株式会社グッドパッチ」の行を更新し、公式情報に「Careers - Member support」リンクを追加しました。
  - 既存の「Goodpatch Blog - 生成AI」「Goodpatch Tech Blog - 生成AI」リンクは維持されています。
  - 他の列（Cursor/Devin/GitHub Copilot/ChatGPT/Claude Code の状態）に変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->