### PR TITLE
Add 株式会社ミラティブ

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,5 +114,6 @@ PRを送っていただけると大変助かります！🙌
 | 合同会社DMM.com | | ✅ | ✅ | 🌀 |🌀 | [DevinとClineをDMMで導入しました〜トライアルから見えた成果の共有〜](https://developersblog.dmm.com/entry/2025/04/04/110000) |
 | [クレジットエンジン株式会社](https://creditengine.jp/) |  |  | ✅ |  | ✅ |全社員の希望者にGitHub Copilot,Claude Codeを支給 <br>またGoogle WorkspaceでGeminiも利用可 |
 | [株式会社マクロミル](https://www.macromill.com/) |🌀|🌀|🌀|✅|🌀|エンジニア・データサイエンス部門で開発系AIエージェント各種を優先導入、全社では社内用AIチャット&Dify(AzureGPT,Gemini)を導入済み。Databricks全社導入済み。|
+| [株式会社ミラティブ](https://www.mirrativ.co.jp/) |✅|✅|✅|✅|✅| 2023年3月よりChatGPT Plusを全社導入。以降、全社員に対して希望者が各種AIツールを使用できるように継続的に環境を整備している。<br>[ミラティブ、全社員を対象に「ChatGPT Plus」の月額利用料を全額補助する福利厚生を導入 今後のサポート強化も予定](https://prtimes.jp/main/html/rd/p/000000095.000033025.html)<br>[CEO×CTO公開1on1 ─ CTO就任からの1年半と、これから。AI時代にエンジニアが「学び続けられる」組織へ](https://note.com/mirrativ/n/n8f6cf66cef22) |
 
 **注:** 上記のチェックマーク（✅）は、各社が公式に発表・確認した導入事例に基づき記載しています。などの出典は各社のプレスリリースや公式ニュースから引用しています。


### PR DESCRIPTION
株式会社ミラティブの千吉良（ちぎら）です。
下記のように情報を記載いたしました。お手すきでご確認いただけますとありがたいです。

| **会社名**                           | **Cursor** | **Devin** | **GitHub Copilot** | **ChatGPT** | **Claude Code** | **公式情報（例：プレスリリース等）**                      |
| --------------------------------- | ---------- | --------- | ------------------ | ----------- | ------------ | ----------------------------------------- |
| [株式会社ミラティブ](https://www.mirrativ.co.jp/) |✅|✅|✅|✅|✅| 2023年3月よりChatGPT Plusを全社導入。以降、全社員に対して希望者が各種AIツールを使用できるように継続的に環境を整備している。<br>[ミラティブ、全社員を対象に「ChatGPT Plus」の月額利用料を全額補助する福利厚生を導入 今後のサポート強化も予定](https://prtimes.jp/main/html/rd/p/000000095.000033025.html)<br>[CEO×CTO公開1on1 ─ CTO就任からの1年半と、これから。AI時代にエンジニアが「学び続けられる」組織へ](https://note.com/mirrativ/n/n8f6cf66cef22) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- ドキュメント
  - READMEの企業一覧に株式会社ミラティブを追加。Cursor、Devin、GitHub Copilot、ChatGPT、Claude Codeの採用状況を全面導入として明記し、公式情報リンクを掲載。
  - 同一の行がREADME内で重複して挿入されています（同内容が2箇所に存在）。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->